### PR TITLE
Adds configurable callback event names

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,6 @@ export class InboxComponent {
 | -------------------- | ------------------------------------------------------------------ | ----------------  |
 | `includeArrays`      | unsubscribe from arrays of observables                             | `false`           |
 | `blackList`          | an array of properties to exclude                                  | `[]`              |
+| `ngOnDestroy`        | a name of event callback to execute on                             | `ngOnDestroy`     |
 
 You can also use https://github.com/NetanelBasal/ngx-take-until-destroy.

--- a/__tests__/auto-unsubscribe.spec.ts
+++ b/__tests__/auto-unsubscribe.spec.ts
@@ -33,7 +33,7 @@ describe('@AutoUnsubscribe', () => {
       obs =  mockObservable;
       ngOnDestroy() {}
     }
-    
+
     new TodsComponent()['ngOnDestroy']();
     expect(consoleSpy).not.toHaveBeenCalled();
   });
@@ -45,7 +45,7 @@ describe('@AutoUnsubscribe', () => {
     class TodsComponent {
       obs =  mockObservable;
     }
-    
+
     new TodsComponent()['ngOnDestroy']();
     expect(consoleSpy).not.toHaveBeenCalled();
   });
@@ -57,7 +57,7 @@ describe('@AutoUnsubscribe', () => {
     class TodsComponent {
       obs =  mockObservable;
     }
-    
+
     new TodsComponent()['ngOnDestroy']();
     expect(consoleSpy).not.toHaveBeenCalled();
   });
@@ -70,6 +70,23 @@ describe('@AutoUnsubscribe', () => {
     }
 
     new TodsComponent().ngOnDestroy();
+    expect(mockObservable.unsubscribe.mock.calls.length).toBe(1);
+  });
+
+  it('should call unsubscribe on custom event callback', () => {
+    @AutoUnsubscribe({event: 'ionViewDidLeave'})
+    class TodsComponent {
+      obs =  mockObservable;
+      ngOnDestroy() {}
+      ionViewDidLeave() {}
+    }
+
+    const cmp = new TodsComponent();
+
+    cmp.ngOnDestroy();
+    expect(mockObservable.unsubscribe.mock.calls.length).toBe(0);
+
+    cmp.ionViewDidLeave();
     expect(mockObservable.unsubscribe.mock.calls.length).toBe(1);
   });
 
@@ -90,13 +107,13 @@ describe('@AutoUnsubscribe', () => {
     @AutoUnsubscribe({blackList: ['obs']})
     class TodsComponent {
       obs =  mockObservable;
-      obs2 =  mockObservable2;      
+      obs2 =  mockObservable2;
       ngOnDestroy() {}
     }
 
     new TodsComponent().ngOnDestroy();
     expect(mockObservable.unsubscribe.mock.calls.length).toBe(0);
-    expect(mockObservable2.unsubscribe.mock.calls.length).toBe(1);    
+    expect(mockObservable2.unsubscribe.mock.calls.length).toBe(1);
   });
 
   it('should unsubscribe an array of subscriptions', () => {

--- a/src/auto-unsubscribe.ts
+++ b/src/auto-unsubscribe.ts
@@ -11,7 +11,7 @@ export function AutoUnsubscribe({ blackList = [], includeArrays = false, event =
       console.warn(`${constructor.name} is using @AutoUnsubscribe but does not implement OnDestroy`);
     }
 
-    constructor.prototype.[event] = function () {
+    constructor.prototype[event] = function () {
       for (let prop in this) {
         const property = this[prop];
         blackList.indexOf(prop) === -1 && property && isFunction(property.unsubscribe) && property.unsubscribe();

--- a/src/auto-unsubscribe.ts
+++ b/src/auto-unsubscribe.ts
@@ -2,16 +2,16 @@ function isFunction( fn ) {
   return typeof fn === 'function';
 }
 
-export function AutoUnsubscribe({ blackList = [], includeArrays = false } = {}) {
+export function AutoUnsubscribe({ blackList = [], includeArrays = false, event = 'ngOnDestroy' } = {}) {
 
   return function (constructor: Function) {
-    const original = constructor.prototype.ngOnDestroy;
+    const original = constructor.prototype[event];
 
     if (!isFunction(original) && !disableAutoUnsubscribeAot()) {
       console.warn(`${constructor.name} is using @AutoUnsubscribe but does not implement OnDestroy`);
     }
 
-    constructor.prototype.ngOnDestroy = function () {
+    constructor.prototype.[event] = function () {
       for (let prop in this) {
         const property = this[prop];
         blackList.indexOf(prop) === -1 && property && isFunction(property.unsubscribe) && property.unsubscribe();


### PR DESCRIPTION
Users of Angular-based frameworks like _Ionic_ might want to unsubscribe before `ngOnDestroy()`. For example, `ionViewDidLeave()` is called when page component is removed from the screen, but it is kept in memory for caching purposes.