### PR TITLE
docs(README): clean up options so table doesn't horizontal scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,32 @@
 [![npm](https://img.shields.io/npm/l/ngx-auto-unsubscribe.svg)]()
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-#### Class decorator that will automatically unsubscribe from observable subscriptions when the component destroyed
+#### Class decorator that will automatically unsubscribe from observable subscriptions when the component is destroyed
 
 ## Installation
+
 `npm install ngx-auto-unsubscribe --save`
 
 ## Usage
+
 ```js
 import { AutoUnsubscribe } from "ngx-auto-unsubscribe";
 
-@AutoUnsubscribe() 
+@AutoUnsubscribe()
 @Component({
   selector: 'inbox'
 })
 export class InboxComponent {
   one: Subscription;
   two: Subscription;
-  
+
   constructor( private store: Store<any>, private element : ElementRef ) {}
-  
+
   ngOnInit() {
     this.one = store.select("data").subscribe(data => // do something);
     this.two = Observable.interval.subscribe(data => // do something);
   }
-  
+
   // If you work with AOT this method must be present, even if empty! 
   // Otherwise 'ng build --prod' will optimize away any calls to ngOnDestroy, 
   // even if the method is added by the @AutoUnsubscribe decorator
@@ -38,15 +40,17 @@ export class InboxComponent {
 }
 ```
 
-
-
 ### Options
 
-| Option               | Description                                                             | Default Value     |
-| -------------------- | ----------------------------------------------------------------------- | ----------------  |
-| `includeArrays`      | unsubscribe from arrays of subscriptions                                | `false`           |
-| `arrayName`          | unsubscribe from subscriptions only in specified array                  | `''`              |
-| `blackList`          | an array of properties to exclude (ignored if `arrayName` is specified) | `[]`              |
-| `ngOnDestroy`        | a name of event callback to execute on                                  | `ngOnDestroy`     |
+| Option            | Description                                                   | Default Value     |
+| ----------------- | ------------------------------------------------------------- | ----------------  |
+| `includeArrays`   | unsubscribe from arrays of subscriptions                      | `false`           |
+| `arrayName`       | unsubscribe from subscriptions only in specified array        | `''`              |
+| `blackList`       | an array of properties to exclude                             | `[]`              |
+| `event`           | a name of event callback to execute on                        | `ngOnDestroy`     |
+
+Note: `blackList` is ignored if `arrayName` is specified.
+
+### Similar projects
 
 You can also use https://github.com/NetanelBasal/ngx-take-until-destroy.


### PR DESCRIPTION
I noticed on [npmjs](https://www.npmjs.com/package/ngx-auto-unsubscribe) the table doesn't fit so you have to scroll horizontally. Fixing that up.

Also fixed a typo: the `event` option was mistakenly called `ngOnDestroy`.